### PR TITLE
Fix CLI spinner dependency

### DIFF
--- a/packages/cli/dist/bin/create-connext.js
+++ b/packages/cli/dist/bin/create-connext.js
@@ -4,6 +4,7 @@ import fsExtra from "fs-extra";
 import path from "path";
 import { fileURLToPath } from "url";
 import chalk from "chalk";
+import ora from "ora";
 const { copy, writeFile } = fsExtra;
 program
     .name("create-connext")
@@ -16,8 +17,9 @@ program
         // Obtener la ruta del directorio actual usando una ruta relativa
         const __dirname = path.dirname(fileURLToPath(import.meta.url));
         const tpl = path.join(__dirname, "../../templates/basic");
-        // Copiar template
+        const copySpinner = ora("Copiando archivos...").start();
         await copy(tpl, dir);
+        copySpinner.succeed();
         // Crear vite.config.js personalizado
         const viteConfig = `import { createConnextConfig } from '@connext/dev-server';
 
@@ -26,7 +28,9 @@ export default createConnextConfig({
   host: 'localhost',
   open: true
 });`;
+        const configSpinner = ora("Creando vite.config.js...").start();
         await writeFile(path.join(dir, 'vite.config.js'), viteConfig);
+        configSpinner.succeed();
         console.log(chalk.green(`✨ Proyecto creado exitosamente en ./${dir}`));
         console.log(chalk.cyan(`\n📦 Instalar dependencias:`));
         console.log(chalk.white(`   cd ${dir} && npm install`));

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "fs-extra": "^11.1.1",
     "commander": "^9.4.1",
-    "chalk": "^5"
+    "chalk": "^5",
+    "ora": "^7.0.1"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/cli/src/bin/create-connext.ts
+++ b/packages/cli/src/bin/create-connext.ts
@@ -4,6 +4,7 @@ import fsExtra from "fs-extra";
 import path from "path";
 import { fileURLToPath } from "url";
 import chalk from "chalk";
+import ora from "ora";
 
 const { copy, writeFile } = fsExtra;
 
@@ -20,8 +21,9 @@ program
       const __dirname = path.dirname(fileURLToPath(import.meta.url));
       const tpl = path.join(__dirname, "../../templates/basic");
       
-      // Copiar template
+      const copySpinner = ora("Copiando archivos...").start();
       await copy(tpl, dir);
+      copySpinner.succeed();
       
       // Crear vite.config.js personalizado
       const viteConfig = `import { createConnextConfig } from '@connext/dev-server';
@@ -32,7 +34,9 @@ export default createConnextConfig({
   open: true
 });`;
       
+      const configSpinner = ora("Creando vite.config.js...").start();
       await writeFile(path.join(dir, 'vite.config.js'), viteConfig);
+      configSpinner.succeed();
       
       console.log(chalk.green(`✨ Proyecto creado exitosamente en ./${dir}`));
       console.log(chalk.cyan(`\n📦 Instalar dependencias:`));


### PR DESCRIPTION
## Summary
- add `ora` spinner to CLI implementation for feedback
- include `ora` as CLI dependency and rebuild

## Testing
- `npm test` *(fails: Error: no test specified)*

------